### PR TITLE
Fixing casting to devices with spaces in their name

### DIFF
--- a/main.js
+++ b/main.js
@@ -85,7 +85,7 @@ mb.on('ready', function ready () {
           //Spawns new subprocess that bridges system audio to the first chromecast found
           //We use a custom node binary because the chromecast-osx-audio module only works
           //on node v0.10
-          chromecast = exec(path.join(__dirname,'/node ',__dirname,'/node_modules/chromecast-osx-audio/bin/chromecast.js -n '+caption+' -p '+port+' -d '+current.label), function (err, stdout, stderr){
+          chromecast = exec(path.join(__dirname,'/node ',__dirname,'/node_modules/chromecast-osx-audio/bin/chromecast.js -n '+caption+' -p '+port+' -d \''+current.label+'\''), function (err, stdout, stderr){
             if (err) {
                 console.log("child processes failed with error code: "+err.code);
             }


### PR DESCRIPTION
I noticed this was only working with devices that had no spaces in their name, so I added quotes in the command to fix this.