### PR TITLE
add speaker next to chromecast audio

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,11 +8,12 @@
     "url": "https://github.com/andresgottlieb/soundcast"
   },
   "dependencies": {
-    "chromecast-osx-audio": "^0.2.1",
+    "chromecast-osx-audio": "danjenkins/node-chromecast-osx-audio#list-json",
     "menubar": "2.3.0",
     "shelljs": "0.5.3"
   },
   "devDependencies": {
+    "electron-packager": "^5.1.0",
     "electron-prebuilt": "0.34.0"
   },
   "main": "main.js",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "url": "https://github.com/andresgottlieb/soundcast"
   },
   "dependencies": {
-    "chromecast-osx-audio": "danjenkins/node-chromecast-osx-audio#list-json",
+    "chromecast-osx-audio": "^0.3.0",
     "menubar": "2.3.0",
     "shelljs": "0.5.3"
   },


### PR DESCRIPTION
Add a Speaker symbol next to Chromecast Audios

Wjile waiting for https://github.com/fardog/node-chromecast-osx-audio/pull/9 to be merged, I've pointed this project at my fork.

The soundcast process doesn't have to kill the node-chromecast-osx-audio process any more as it kills itself.

<img width="169" alt="screen shot 2015-12-07 at 12 35 40" src="https://cloud.githubusercontent.com/assets/243117/11627002/2190b4ae-9cdf-11e5-87d6-ca9621904004.png">