### PR TITLE
Update readme to denote the app does not work with single quotes in a chromecast's name

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ electron-packager . soundcast --platform=darwin --arch=x64 --version=0.36.0 --ic
 ## Known issues
 - Unexpected behavior when trying to cast to a Chromecast while it's booting (or just booted). This is an issue in the `chromecast-osx-audio` module dependency.
 - Sometimes the default `menubar` cat icon is shown for a few seconds instead of the Chromecast icon when launching Soundcast.
-- Incompatible with chromecasts including double quotes (") in their name.
+- Incompatible with chromecasts including double quotes (") or single quotes (') in their name.
  
 ## Windows users
 


### PR DESCRIPTION
Fixes #35 